### PR TITLE
Drop license_family

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,6 @@ about:
   home: https://libraryofcongress.github.io/bagit-python/
   summary: 'Work with BagIt packages from Python'
   license: Public-Domain
-  license_family: PUBLIC-DOMAIN
   dev_url: https://github.com/LibraryOfCongress/bagit-python
   doc_url: https://libraryofcongress.github.io/bagit-python/
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,7 @@ about:
   home: https://libraryofcongress.github.io/bagit-python/
   summary: 'Work with BagIt packages from Python'
   license: Public-Domain
-  license_family: Public-Domain
+  license_family: PUBLIC-DOMAIN
   dev_url: https://github.com/LibraryOfCongress/bagit-python
   doc_url: https://libraryofcongress.github.io/bagit-python/
 


### PR DESCRIPTION
This apparently now must be all caps. So this fixes it. Alternatively we can drop this field entirely as it may be on its way out. For now, just fixing it so that the feedstocks update and team update script can proceed. Currently it is failing.

xref: https://github.com/conda/conda-build/pull/1761
xref: https://github.com/conda/conda-build/pull/1744
xref: https://github.com/conda/conda-build/issues/1780
ref: https://travis-ci.org/conda-forge/conda-forge.github.io/jobs/211185472